### PR TITLE
Update/fix requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,16 @@
-numpy==1.23.4
-face_alignment==1.3.5
-imageio==2.19.3
-imageio-ffmpeg==0.4.7
-librosa==0.9.2 # 
-numba
-resampy==0.3.1
+face_alignment==1.4.1
+imageio==2.31.5
+imageio-ffmpeg==0.4.9
+librosa==0.10.1 #LibRosa requires numba and so then numpy, so don't specify requirements.
+resampy==0.4.2
 pydub==0.25.1 
-scipy==1.10.1
-kornia==0.6.8
+scipy==1.11.3
+kornia==0.7.0
 tqdm
 yacs==0.1.8
 pyyaml  
-joblib==1.1.0
-scikit-image==0.19.3
+joblib==1.3.2
+scikit-image==0.21.0
 basicsr==1.4.2
 facexlib==0.3.0
 gradio

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 face_alignment==1.4.1
 imageio==2.31.5
 imageio-ffmpeg==0.4.9
-librosa==0.10.1 #LibRosa requires numba and so then numpy, so don't specify requirements.
+librosa>=0.10.1 #LibRosa requires numba and so then numpy, so don't specify requirements.
 resampy==0.4.2
 pydub==0.25.1 
 scipy==1.11.3


### PR DESCRIPTION
Lots of issues with Sadtalker and other extensions, which I effectively sorted out to being related to the strict dependencies, specifically for numba > numpy > librosa. Removing the restrictions on numba+numpy and bumping librosa fixes issues with other extensions.