### PR TITLE
通过修改app_sadtalker.py解决了gradio4带来的问题; 增加Windows下的download模型的脚本

### DIFF
--- a/app_sadtalker.py
+++ b/app_sadtalker.py
@@ -32,17 +32,20 @@ def sadtalker_demo(checkpoint_path='checkpoints', config_path='src/config', warp
                     <a style='font-size:18px;color: #efefef' href='https://sadtalker.github.io'>Homepage</a>  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; \
                      <a style='font-size:18px;color: #efefef' href='https://github.com/Winfredy/SadTalker'> Github </div>")
         
-        with gr.Row().style(equal_height=False):
+        with gr.Row(equal_height=False): 
             with gr.Column(variant='panel'):
                 with gr.Tabs(elem_id="sadtalker_source_image"):
                     with gr.TabItem('Upload image'):
                         with gr.Row():
-                            source_image = gr.Image(label="Source image", source="upload", type="filepath", elem_id="img2img_image").style(width=512)
+                            source_image = gr.Image(label="Source image", 
+                                                    type="filepath", 
+                                                    elem_id="img2img_image", width=512)
 
                 with gr.Tabs(elem_id="sadtalker_driven_audio"):
                     with gr.TabItem('Upload OR TTS'):
                         with gr.Column(variant='panel'):
-                            driven_audio = gr.Audio(label="Input audio", source="upload", type="filepath")
+                            driven_audio = gr.Audio(label="Input audio", 
+                                                    type="filepath")
 
                         if sys.platform != 'win32' and not in_webui: 
                             from src.utils.text2speech import TTSTalker

--- a/scripts/download_models.ps1
+++ b/scripts/download_models.ps1
@@ -1,0 +1,30 @@
+# Create directory
+mkdir ".\checkpoints"
+
+# Legacy download links
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/auido2exp_00300-model.pth" -OutFile ".\checkpoints\auido2exp_00300-model.pth"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/auido2pose_00140-model.pth" -OutFile ".\checkpoints\auido2pose_00140-model.pth"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/epoch_20.pth" -OutFile ".\checkpoints\epoch_20.pth"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/facevid2vid_00189-model.pth.tar" -OutFile ".\checkpoints\facevid2vid_00189-model.pth.tar"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/shape_predictor_68_face_landmarks.dat" -OutFile ".\checkpoints\shape_predictor_68_face_landmarks.dat"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/wav2lip.pth" -OutFile ".\checkpoints\wav2lip.pth"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/mapping_00229-model.pth.tar" -OutFile ".\checkpoints\mapping_00229-model.pth.tar"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/mapping_00109-model.pth.tar" -OutFile ".\checkpoints\mapping_00109-model.pth.tar"
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/hub.zip" -OutFile ".\checkpoints\hub.zip"
+# Expand-Archive -Path ".\checkpoints\hub.zip" -DestinationPath ".\checkpoints\" -Force
+
+# Download the new links
+Invoke-WebRequest -Uri "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/mapping_00109-model.pth.tar" -OutFile ".\checkpoints\mapping_00109-model.pth.tar"
+Invoke-WebRequest -Uri "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/mapping_00229-model.pth.tar" -OutFile ".\checkpoints\mapping_00229-model.pth.tar"
+Invoke-WebRequest -Uri "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/SadTalker_V0.0.2_256.safetensors" -OutFile ".\checkpoints\SadTalker_V0.0.2_256.safetensors"
+Invoke-WebRequest -Uri "https://github.com/OpenTalker/SadTalker/releases/download/v0.0.2-rc/SadTalker_V0.0.2_512.safetensors" -OutFile ".\checkpoints\SadTalker_V0.0.2_512.safetensors"
+
+# Invoke-WebRequest -Uri "https://github.com/Winfredy/SadTalker/releases/download/v0.0.2/BFM_Fitting.zip" -OutFile ".\checkpoints\BFM_Fitting.zip"
+# Expand-Archive -Path ".\checkpoints\BFM_Fitting.zip" -DestinationPath ".\checkpoints\" -Force
+
+# Enhancer
+mkdir ".\gfpgan\weights"
+Invoke-WebRequest -Uri "https://github.com/xinntao/facexlib/releases/download/v0.1.0/alignment_WFLW_4HG.pth" -OutFile ".\gfpgan\weights\alignment_WFLW_4HG.pth"
+Invoke-WebRequest -Uri "https://github.com/xinntao/facexlib/releases/download/v0.1.0/detection_Resnet50_Final.pth" -OutFile ".\gfpgan\weights\detection_Resnet50_Final.pth"
+Invoke-WebRequest -Uri "https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth" -OutFile ".\gfpgan\weights\GFPGANv1.4.pth"
+Invoke-WebRequest -Uri "https://github.com/xinntao/facexlib/releases/download/v0.2.2/parsing_parsenet.pth" -OutFile ".\gfpgan\weights\parsing_parsenet.pth"


### PR DESCRIPTION
前者解决了Issue https://github.com/OpenTalker/SadTalker/issues/721 https://github.com/OpenTalker/SadTalker/issues/694 https://github.com/OpenTalker/SadTalker/issues/693 https://github.com/OpenTalker/SadTalker/issues/692
后者可以让Issue https://github.com/OpenTalker/SadTalker/issues/493 更加清晰

因为现在requirements.txt没指定gradio的版本，默认下载的是最新的gradio==4.10.0， 所以那几个issue就报这个问题

改了就没问题了