### PR TITLE
Fix the issue where SadTalker cannot be used on Stable Diffusion webui 1.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.23.4
 face_alignment==1.3.5
 imageio==2.19.3
 imageio-ffmpeg==0.4.7
-librosa==0.9.2 # 
+librosa==0.10.1 # 
 numba
 resampy==0.3.1
 pydub==0.25.1 

--- a/src/face3d/util/my_awing_arch.py
+++ b/src/face3d/util/my_awing_arch.py
@@ -15,7 +15,7 @@ def calculate_points(heatmaps):
     indexes = np.argmax(heatline, axis=2)
 
     preds = np.stack((indexes % W, indexes // W), axis=2)
-    preds = preds.astype(np.float, copy=False)
+    preds = preds.astype(np.float32, copy=False)
 
     inr = indexes.ravel()
 

--- a/src/face3d/util/preprocess.py
+++ b/src/face3d/util/preprocess.py
@@ -98,6 +98,6 @@ def align_img(img, lm, lm3D, mask=None, target_size=224., rescale_factor=102.):
 
     # processing the image
     img_new, lm_new, mask_new = resize_n_crop_img(img, lm, t, s, target_size=target_size, mask=mask)
-    trans_params = np.array([w0, h0, s, t[0], t[1]])
+    trans_params = np.array([w0, h0, s, t[0], t[1]], dtype=object)
 
     return trans_params, img_new, lm_new, mask_new


### PR DESCRIPTION
For specific details, update to 1.8.0 using SadTalker with an error message np. complex, and then upgrade librosa to 0.10 Subsequently, we encountered an issue with "AttributeError: module 'numpy' has no attribute 'float'" and updated the code to np.float32
 Then we encountered the issue of "alueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimension. The detected shape was (5,)+inhomogeneous pa". In response to the error message, we added the dtype attribute of np. array, and now it is running normally
![image](https://github.com/OpenTalker/SadTalker/assets/5028386/dc3758c6-34cf-4607-ae8f-ac13625daab3)
![image](https://github.com/OpenTalker/SadTalker/assets/5028386/7f749584-dcff-4963-be4c-f172c8e46248)
![image](https://github.com/OpenTalker/SadTalker/assets/5028386/166211ef-3ef0-4458-9ece-caab916cf41b)
![image](https://github.com/OpenTalker/SadTalker/assets/5028386/0b5dc920-42c7-4278-a063-fc1d3a5c4bdd)
The effect of the final normal image：
![image](https://github.com/OpenTalker/SadTalker/assets/5028386/f5aac855-c00a-49ba-b495-76e1f5fb6a70)
